### PR TITLE
Add vLLM support for Gemma-3-1b-it

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -55,7 +55,10 @@ def register_tt_models():
     ModelRegistry.register_model(
         "TTMistralForCausalLM",
         "models.tt_transformers.tt.generator_vllm:MistralForCausalLM")
-
+    ModelRegistry.register_model(
+        "TTGemma3ForCausalLM",
+        "models.tt_transformers.tt.generator_vllm:Gemma3ForCausalLM"
+    )
 
 register_tt_models()  # Import and register models from tt-metal
 
@@ -121,6 +124,7 @@ def check_tt_model_supported(model):
         "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
         "mistralai/Mistral-7B-Instruct-v0.3",
+        "google/gemma-3-1b-it",
     ]
     assert model in supported_models, f"Invalid model: {model}"
 


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR is to enable vLLM support for gemma-3-1b-it

## Test ran
MESH_DEVICE=N150 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "google/gemma-3-1b-it" --max_seqs_in_batch 1

Device used: n150